### PR TITLE
removed unnecessary .clearfix from clearfix section

### DIFF
--- a/grid.css.less
+++ b/grid.css.less
@@ -163,7 +163,6 @@
 }
 
 // Manually adding .clearfix() classes since LESSPHP has trouble with them.
-.clearfix,
 .clearfix:before,
 .clearfix:after,
 .container:before,


### PR DESCRIPTION
removed .clearfix from the clearfix section, because it was changing the 'display' rule for the affected element to 'table';